### PR TITLE
update post.rss - UK Data Scientist

### DIFF
--- a/posts.rss
+++ b/posts.rss
@@ -39,5 +39,10 @@
        <link>https://apeel.com/careers?gh_jid=2688324</link>
        <description>Software Eningeer II, Santa Barbara, CA</description>
     </item>
+    <item>
+       <title>Mantle Labs</title>
+       <link>https://www.joshswaterjobs.com/jobs/31834</link>
+       <description>Data Scientist, United Kingdom</description>
+    </item>
   </channel>
 </rss>


### PR DESCRIPTION
added UK-based data science position to `post.rss`

NOTE: If the link doesn't meet your criteria I am happy to post directly to the job spec (word document on google drive) or alter the advert in a way that you see fit. What a wonderful resource you are developing!